### PR TITLE
fix: non-sponsored estimate via EntryPoint deposit override

### DIFF
--- a/src/rpc/estimation/utils.ts
+++ b/src/rpc/estimation/utils.ts
@@ -17,9 +17,12 @@ import {
     type Hex,
     type StateOverride,
     decodeErrorResult,
+    encodeAbiParameters,
     getAbiItem,
     keccak256,
+    pad,
     parseAbi,
+    parseEther,
     toHex
 } from "viem"
 import { entryPoint06Abi } from "viem/account-abstraction"
@@ -63,6 +66,39 @@ export function parseFailedOpWithRevert(data: Hex) {
     } catch {}
 
     return data
+}
+
+// Compute the storage slot for `deposits[sender].deposit` in EntryPoint v0.7/v0.8
+// storage. EntryPoint inherits StakeManager first (after the interface IEntryPoint
+// which contributes no storage), so the `deposits` mapping lives at slot 0. The
+// DepositInfo struct's first field is `uint256 deposit`, which sits exactly at the
+// computed mapping slot.
+//
+// Why we override this: during simulation of a non-sponsored userOp, the EntryPoint
+// reads `bal = balanceOf(sender)` (= `deposits[sender].deposit`) to compute
+// `missingAccountFunds`. If the sender has zero EP deposit (the common case — users
+// fund their wallet, not the EP), the account is asked to transfer the prefund out
+// of its own balance. For accounts that don't hold native ETH (e.g., UR-sponsored
+// flows), this prevents the binary-search probes from succeeding and the estimator
+// returns verificationGasLimit=0.
+//
+// By overriding the EP's deposit slot for the sender to a large value, we make
+// `missingAccountFunds = 0` during simulation. The account's `_payPrefund(0)` is a
+// no-op, so the wallet balance is never touched — meaning callData simulation still
+// uses the *real* wallet balance, and ETH transfers in callData fail truthfully if
+// the account is under-funded.
+export function getEntryPointDepositOverride(
+    sender: Address,
+    amount: bigint = parseEther("100")
+): { slot: Hex; value: Hex } {
+    const slot = keccak256(
+        encodeAbiParameters(
+            [{ type: "address" }, { type: "uint256" }],
+            [sender, 0n]
+        )
+    )
+    const value = pad(toHex(amount), { size: 32 })
+    return { slot, value }
 }
 
 // Helper function that adds EIP-7702 overrides if needed, and converts to viem format.

--- a/src/rpc/estimation/utils.ts
+++ b/src/rpc/estimation/utils.ts
@@ -71,16 +71,21 @@ export function parseFailedOpWithRevert(data: Hex) {
 // Compute the storage slot for `deposits[sender].deposit` in EntryPoint storage.
 // Works uniformly for EntryPoint v0.6, v0.7, and v0.8: in all three, EntryPoint
 // inherits StakeManager first (after the interface IEntryPoint, which contributes
-// no storage), so the `deposits` mapping lives at slot 0. The DepositInfo struct's
-// first field is `uint256 deposit`, which sits exactly at the computed mapping slot.
+// no storage), so the `deposits` mapping lives at slot 0. `DepositInfo`'s first
+// field — `uint112 deposit` in v0.6 (see contracts/src/v06/...) and `uint256
+// deposit` in v0.7/v0.8 — sits at the low bytes of the computed mapping slot.
+// Writing a 32-byte value works for both layouts because the override amount
+// fits in uint112 and Solidity reads the low bits of the slot for the field.
 //
-// Why we override this: during simulation of a non-sponsored userOp, the EntryPoint
-// reads `bal = balanceOf(sender)` (= `deposits[sender].deposit`) to compute
-// `missingAccountFunds`. If the sender has zero EP deposit (the common case — users
-// fund their wallet, not the EP), the account is asked to transfer the prefund out
-// of its own balance. For accounts that don't hold native ETH (e.g., UR-sponsored
-// flows), this prevents the binary-search probes from succeeding and the estimator
-// returns verificationGasLimit=0.
+// Why we override this: during simulation we coerce the userOp's fees to 1 wei
+// (see eth_estimateUserOperationGas) so gas math stays well-defined, but only
+// for *boosted* userOps (original fees=0). The EntryPoint then computes
+// `missingAccountFunds` as the prefund minus `balanceOf(sender)` (i.e.
+// `deposits[sender].deposit`) and asks the account to transfer the difference
+// out of its own wallet balance. A boosted userOp typically comes from an
+// unfunded sender — by the time it reaches us the wallet has neither ETH nor
+// any EP deposit — so the prefund transfer fails and the binary-search probes
+// return verificationGasLimit=0, surfacing later as AA23 on send.
 //
 // By overriding the EP's deposit slot for the sender to a large value, we make
 // `missingAccountFunds = 0` during simulation. The account's `_payPrefund(0)` is a

--- a/src/rpc/estimation/utils.ts
+++ b/src/rpc/estimation/utils.ts
@@ -68,11 +68,11 @@ export function parseFailedOpWithRevert(data: Hex) {
     return data
 }
 
-// Compute the storage slot for `deposits[sender].deposit` in EntryPoint v0.7/v0.8
-// storage. EntryPoint inherits StakeManager first (after the interface IEntryPoint
-// which contributes no storage), so the `deposits` mapping lives at slot 0. The
-// DepositInfo struct's first field is `uint256 deposit`, which sits exactly at the
-// computed mapping slot.
+// Compute the storage slot for `deposits[sender].deposit` in EntryPoint storage.
+// Works uniformly for EntryPoint v0.6, v0.7, and v0.8: in all three, EntryPoint
+// inherits StakeManager first (after the interface IEntryPoint, which contributes
+// no storage), so the `deposits` mapping lives at slot 0. The DepositInfo struct's
+// first field is `uint256 deposit`, which sits exactly at the computed mapping slot.
 //
 // Why we override this: during simulation of a non-sponsored userOp, the EntryPoint
 // reads `bal = balanceOf(sender)` (= `deposits[sender].deposit`) to compute

--- a/src/rpc/methods/eth_estimateUserOperationGas.ts
+++ b/src/rpc/methods/eth_estimateUserOperationGas.ts
@@ -6,7 +6,6 @@ import {
     ValidationErrors,
     estimateUserOperationGasSchema
 } from "@alto/types"
-import { parseEther, toHex } from "viem"
 import { maxBigInt, scaleBigIntByPercent } from "../../utils/bigInt"
 import {
     calcExecutionPvgComponent,
@@ -14,6 +13,7 @@ import {
 } from "../../utils/preVerificationGasCalulator"
 import { deepHexlify, isVersion06, isVersion07 } from "../../utils/userop"
 import { createMethodHandler } from "../createMethodHandler"
+import { getEntryPointDepositOverride } from "../estimation/utils"
 import type { RpcHandler } from "../rpcHandler"
 
 type GasEstimateResult =
@@ -111,33 +111,35 @@ const getGasEstimates = async ({
         entryPoint
     })
 
+    // Force simulation fees to 1 wei so the EntryPoint returns meaningful `paid` values
+    // for callGasLimit calculation (v0.6 derives it via `paid / maxFeePerGas`, undefined
+    // at 0; v0.7+ also keeps the binary-search math well-defined).
     const simulationUserOp = {
         ...userOp,
+        maxFeePerGas: 1n,
+        maxPriorityFeePerGas: 1n,
         preVerificationGas: 0n,
         verificationGasLimit: simulationVerificationGasLimit,
         callGasLimit: simulationCallGasLimit
     }
 
-    // For v0.6 boosted userOps (maxFeePerGas=0), simulate with maxFeePerGas=1
-    // so the EntryPoint returns meaningful `paid` values for callGasLimit calculation.
-    if (
-        isVersion06(simulationUserOp) &&
-        userOp.maxFeePerGas === 0n &&
-        userOp.maxPriorityFeePerGas === 0n
-    ) {
-        // gas estimation simulation is done with maxFeePerGas/maxPriorityFeePerGas = 1.
-        // Because of this, sender must have atleast maxGas of wei.
-        const maxGas = parseEther("100000000")
-
-        simulationUserOp.maxFeePerGas = 1n
-        simulationUserOp.maxPriorityFeePerGas = 1n
-
+    // For boosted userOps (original fees=0), pre-deposit funds for the sender at the
+    // EntryPoint so the resulting 1-wei-fee prefund check passes without touching the
+    // sender's wallet balance — preserving the ability for callData ETH transfers to
+    // fail truthfully if the wallet is under-funded.
+    const isBoosted =
+        userOp.maxFeePerGas === 0n && userOp.maxPriorityFeePerGas === 0n
+    if (isBoosted) {
         if (mutableStateOverrides === undefined) {
             mutableStateOverrides = {}
         }
-        mutableStateOverrides[userOp.sender] = {
-            ...deepHexlify(mutableStateOverrides[userOp.sender] || {}),
-            balance: toHex(maxGas)
+        const deposit = getEntryPointDepositOverride(userOp.sender)
+        mutableStateOverrides[entryPoint] = {
+            ...deepHexlify(mutableStateOverrides[entryPoint] || {}),
+            stateDiff: {
+                ...(mutableStateOverrides[entryPoint]?.stateDiff || {}),
+                [deposit.slot]: deposit.value
+            }
         }
     }
 

--- a/test/e2e/tests/eth_estimateUserOperationGas.test.ts
+++ b/test/e2e/tests/eth_estimateUserOperationGas.test.ts
@@ -234,6 +234,84 @@ describe.each([
             expect(estimation.callGasLimit).toBe(0n)
         })
 
+        // Regression: estimation must succeed for "boosted" userOps (fees=0)
+        // even when the sender has zero wallet balance AND zero EntryPoint
+        // deposit. Without the EntryPoint deposit slot stateDiff override
+        // (see getEntryPointDepositOverride), the prefund check fails during
+        // simulation and the estimator returns verificationGasLimit=0,
+        // causing AA23 on later send.
+        //
+        // We bypass viem's prepareUserOperation here because it internally
+        // calls estimateUserOperationGas with the account's *real* fees
+        // (from estimateFeesPerGas), which would itself fail on an unfunded
+        // sender — defeating the point of the regression. Building the userOp
+        // directly with fees=0 from the start exercises the boosted path.
+        test("Can estimate boosted userOp (fees=0) for unfunded sender", async () => {
+            const smartAccountClient = await getSmartAccountClient({
+                entryPointVersion,
+                anvilRpc,
+                altoRpc,
+                fundAccount: false
+            })
+
+            const bundlerClient = createBundlerClient({
+                chain: foundry,
+                transport: http(altoRpc)
+            })
+
+            const account = smartAccountClient.account
+            const callData = await account.encodeCalls([
+                {
+                    to: "0x23B608675a2B2fB1890d3ABBd85c5775c51691d5",
+                    data: "0x",
+                    value: 0n
+                }
+            ])
+            const nonce = await account.getNonce()
+            const factoryArgs = await account.getFactoryArgs()
+            const stubSignature = await account.getStubSignature()
+
+            const baseUserOp = {
+                sender: account.address,
+                nonce,
+                callData,
+                callGasLimit: 0n,
+                verificationGasLimit: 0n,
+                preVerificationGas: 0n,
+                maxFeePerGas: 0n,
+                maxPriorityFeePerGas: 0n,
+                signature: stubSignature
+            }
+            const userOp =
+                entryPointVersion === "0.6"
+                    ? {
+                          ...baseUserOp,
+                          initCode:
+                              factoryArgs.factory && factoryArgs.factoryData
+                                  ? `${factoryArgs.factory}${factoryArgs.factoryData.slice(2)}`
+                                  : "0x",
+                          paymasterAndData: "0x"
+                      }
+                    : {
+                          ...baseUserOp,
+                          factory: factoryArgs.factory,
+                          factoryData: factoryArgs.factoryData
+                      }
+
+            const estimation = (await bundlerClient.request({
+                method: "eth_estimateUserOperationGas",
+                params: [deepHexlify(userOp), entryPoint]
+            })) as {
+                verificationGasLimit: Hex
+                callGasLimit: Hex
+                preVerificationGas: Hex
+            }
+
+            expect(BigInt(estimation.verificationGasLimit)).toBeGreaterThan(0n)
+            expect(BigInt(estimation.callGasLimit)).toBeGreaterThan(0n)
+            expect(BigInt(estimation.preVerificationGas)).toBeGreaterThan(0n)
+        })
+
         test("Should throw revert reason if simulation reverted during callphase", async () => {
             const smartAccountClient = await getSmartAccountClient({
                 entryPointVersion,


### PR DESCRIPTION
## Problem

`eth_estimateUserOperationGas` for non-sponsored v0.7 userOps was returning `verificationGasLimit: 0`, which then caused `AA23 reverted 0x` (OOG inside the smart account's `validateUserOp` because EP calls `validateUserOp{gas: 0}`) when the SDK signed and submitted the resulting userOp.

The root cause was a regression introduced when an earlier fix removed the unconditional `simulationUserOp.maxFeePerGas = 1n` override during simulation. With real fees in the simulation, `requiredPrefund = totalGas × realFee` could be sizeable, and the account's prefund payment in `_payPrefund` would either OOG or fail to transfer (since sender's EP deposit was 0), tripping the binary-search probes and producing `verificationGasLimit: 0`.

## Fix

1. **Restore upstream Alto's `simulationUserOp.maxFeePerGas = 1n`** unconditionally for all userOps in the simulation copy. Required for v0.6 callGasLimit math (`paid / maxFeePerGas` is undefined at 0); also keeps v0.7+ binary-search math well-defined and avoids the prefund-amplification problem.

2. **For boosted userOps** (original fees == 0), override the EntryPoint's `deposits[sender].deposit` storage slot to 100 ETH for the simulation. Slot calc: `keccak256(abi.encode(sender, 0))` — `deposits` is the sole state variable in `StakeManager` (the first storage-bearing parent of EntryPoint v0.6/v0.7/v0.8). Sponsored UR senders typically hold zero EP deposit (UR's bundler EOA covers gas), so without this the 1-wei-fee prefund check fails AA21.

## Why deposit-slot override and not wallet balance override (the previous approach)

Overriding the sender's *wallet* balance leaked into `callData` simulation: an account trying to transfer ETH it doesn't have would falsely succeed during simulation and then revert onchain, wasting the bundler EOA's gas.

Overriding the *EntryPoint's deposit slot* keeps the wallet balance untouched:
- During validate: EP reads `bal = balanceOf(sender)` (= `deposits[sender].deposit`) → returns the overridden value → `missingAccountFunds = 0` → `account.validateUserOp(..., 0)` → `_payPrefund(0)` is a no-op → wallet balance never touched
- During execute (callData phase): wallet has its real balance → ETH transfers fail truthfully if the account is under-funded

## Cross-version coverage

The fix is intentionally version-agnostic. Slot 0 holds `deposits` for all three EP versions because `StakeManager` is the first storage-bearing parent in each (`IEntryPoint` is interface-only):

| Mode | v0.6 | v0.7 | v0.8 |
|---|---|---|---|
| Boosted (original fees=0) | ✅ deposit override applied | ✅ | ✅ |
| Non-sponsored (real fees) | ✅ — `maxFeePerGas=1n` simulation override makes prefund trivial, no deposit override needed | ✅ | ✅ |
| Paymaster-sponsored | ✅ — paymaster's deposit is what's checked; override is a no-op for sender | ✅ | ✅ |

The v0.6 simulation deploys `EntryPointGasEstimationOverride06` *at* the EP address (code override). That contract has the same inheritance chain — `IEntryPoint, StakeManager, NonceManager, ReentrancyGuard` — and its only addition is a `private constant` (no storage). So `keccak256(abi.encode(sender, 0))` resolves to `deposits[sender].deposit` correctly. Our `stateDiff` is preserved alongside the code override by the merge in `prepareStateOverride`.

The v0.7/v0.8 simulation reaches EP via `delegateAndRevert(entryPointSimulation, data)` — the delegate-call runs the simulation code in EP's storage context, so reads of `deposits[sender]` see our override.

## Verified locally

Tested against a Kernel v3.3 EOA-derived account on Sepolia covering all four scenarios:

| Combo | Outcome |
|---|---|
| UR sponsored (boosted) | ✅ estimates and lands |
| Pimlico sponsored | ✅ estimates and lands |
| Pimlico non-sponsored | ✅ estimates and lands (via meta-aa-provider routing) |
| UR non-sponsored | ✅ estimates and lands (was AA23 before this fix) |

Plus an under-funded `callData` ETH transfer case correctly fails simulation with the actual revert reason instead of falsely succeeding.