### PR TITLE
chore: remove debug log and clarify max-bundle-count description

### DIFF
--- a/src/cli/config/options.ts
+++ b/src/cli/config/options.ts
@@ -101,8 +101,11 @@ export const bundlerOptions: CliCommandOptions<IBundlerArgsInput> = {
         default: "20000000"
     },
     "max-bundle-count": {
+        // Cap is enforced in src/mempool/mempool.ts:725-773 (getBundles loop):
+        // it limits how many bundles `getBundles()` returns per iteration,
+        // not how many UserOperations end up inside a single bundle.
         description:
-            "Maximum number of UserOperations to include in a bundle. If not set, no limit is applied.",
+            "Maximum number of bundles produced per getBundles iteration (caps loop output, not per-bundle UserOp count)",
         type: "number",
         require: false
     },

--- a/src/rpc/methods/eth_sendUserOperation.ts
+++ b/src/rpc/methods/eth_sendUserOperation.ts
@@ -222,7 +222,6 @@ export const ethSendUserOperationHandler = createMethodHandler({
     method: "eth_sendUserOperation",
     schema: sendUserOperationSchema,
     handler: async ({ rpcHandler, params, apiVersion }) => {
-        console.log("=== eth_sendUserOperation called ===")
         const [userOp, entryPoint] = params
 
         let status: "added" | "queued" | "rejected" = "rejected"


### PR DESCRIPTION
Two minor cleanups discovered during AAStar's downstream fork acceptance review.

## What

1. **Remove leftover debug `console.log`** in `eth_sendUserOperation` handler  
   `src/rpc/methods/eth_sendUserOperation.ts:225` —  
   `console.log("=== eth_sendUserOperation called ===")` was introduced in commit `702f9af` (alto merge) and appears to be a debug residual. It fires on every `eth_sendUserOperation` call.

2. **Clarify `--max-bundle-count` CLI description**  
   `src/cli/config/options.ts:103-108` —  
   The current description says *"Maximum number of UserOperations to include in a bundle"*, but the actual behavior (see `src/mempool/mempool.ts:725-773`, `getBundles` loop break condition `bundles.length >= maxBundleCount`) caps the **number of bundles produced per `getBundles()` iteration**, not the per-bundle UserOp count. The previous wording misled operators configuring the flag in our deployment.

## Why upstream

Both are present in the current `main` HEAD and affect any downstream consumer. AAStar found these during M1 acceptance review of our fork (`AAStarCommunity/UltraRelay-AAStar`) and we'd like to feed them back so all downstream forks benefit.

## No behavior change

- The `console.log` removal is pure noise reduction.
- The CLI description change is documentation only — no runtime behavior changes.

## Test

Lint passes (`pnpm run lint`). No new tests needed (no behavior change).

## Context

AAStar maintains a downstream fork at https://github.com/AAStarCommunity/UltraRelay-AAStar tracking ZeroDev/ultra-relay for our SuperPaymaster + xPNTs gasless infrastructure. We plan monthly upstream sync and will feed back any non-AAStar-specific improvements.