### PR TITLE
fix: dedupe EIP-7702 stateOverrides by sender

### DIFF
--- a/src/utils/eip7702.ts
+++ b/src/utils/eip7702.ts
@@ -1,28 +1,34 @@
-import { type StateOverride, concat } from "viem"
+import { type Address, type Hex, type StateOverride, concat } from "viem"
 import type { UserOperation } from "../types/schemas"
 
 export const getEip7702DelegationOverrides = (
     userOps: UserOperation[]
 ): StateOverride | undefined => {
-    const stateOverride: StateOverride = []
+    // Dedupe by sender. When a bundle contains multiple userOps from the
+    // same sender (a common back-to-back submission pattern), pushing one
+    // stateOverride entry per userOp produces duplicate `address` entries
+    // in the array. viem rejects that with:
+    //   `State for account "0x..." is set multiple times.`
+    // The whole filterOps simulation aborts and both userOps get evicted
+    // from the mempool. The delegate code is the same for every userOp
+    // from a given sender (the EIP-7702 authorization points at the same
+    // implementation), so collapsing to one entry per sender is safe.
+    const codeBySender = new Map<Address, Hex>()
 
     for (const userOp of userOps) {
-        if (userOp.eip7702Auth) {
-            const delegate =
-                "address" in userOp.eip7702Auth
-                    ? userOp.eip7702Auth.address
-                    : userOp.eip7702Auth.contractAddress
+        if (!userOp.eip7702Auth) continue
 
-            stateOverride.push({
-                address: userOp.sender,
-                code: concat(["0xef0100", delegate])
-            })
-        }
+        const delegate =
+            "address" in userOp.eip7702Auth
+                ? userOp.eip7702Auth.address
+                : userOp.eip7702Auth.contractAddress
+
+        codeBySender.set(userOp.sender, concat(["0xef0100", delegate]))
     }
 
-    if (stateOverride.length === 0) {
+    if (codeBySender.size === 0) {
         return undefined
     }
 
-    return stateOverride
+    return Array.from(codeBySender, ([address, code]) => ({ address, code }))
 }


### PR DESCRIPTION
## Summary

When a bundle being simulated via `filterOps` contained multiple userOps from the same sender, `getEip7702DelegationOverrides` pushed one `stateOverride` entry per userOp keyed by `userOp.sender`. The resulting array carried duplicate `address` entries, and viem's `publicClient.call` rejected the simulation with:

```
State for account "0x..." is set multiple times.
```

The whole bundle aborted (`filterops_failed` in `executor_manager`), both userOps were evicted from the mempool, and meta-aa's billing retried 10× before marking them `UOP_NF` in `pending_transactions`.

## Why this happens to UR specifically

The mempool intentionally permits multiple userOps per sender when they use different **nonceKeys** (the high 192 bits of EP v0.7's nonce, i.e. parallel nonce channels). That's a feature — it lets a single account fire multiple in-flight userOps that get batched into one bundle. Observed pair on Arbitrum:

```
sender 0x3916484216f6d0Cef056a6C4Ca5C840FB4C9260A
uop1: nonceKey=0x53c1c9ca366fb03256d26859ffea84d51231689e6bdd, seq=0
uop2: nonceKey=0x326f082f29f9b2d3394cdbda4d69a571472757d6eb5e, seq=0  ← different channel
```

The mempool batched them correctly. The override builder didn't know about that pattern.

## Fix

Switch the local accumulator from `StateOverride[]` to `Map<Address, Hex>`. Same sender just overwrites — and since the EIP-7702 delegate is identical for every userOp from a given smart account (one Kernel impl per account), the collapsed entry is correct.

`getFilterOpsStateOverride` already emits one entry keyed by the EntryPoint, so this was the only collision surface.

## Why last-write-wins is safe

viem's `stateOverride` is a single snapshot for the entire `eth_call` — each `address` must be unique. Per-userOp staging of different delegate codes was already unsimulatable; the old code would have been rejected by viem the same way. In practice all userOps from one sender in a bundle share a delegate, so the dedup is a no-op semantically.

## Impact (Arbitrum, last 7 days)

- ~13 userOps dropped, ~1-2 incidents/day
- Bursty: May 9 had 14 issue lines, May 10 had 0, May 11 had 7
- Pattern: same sender, different nonceKeys, both userOps in a bundle → `UOP_NF`

Other chains likely affected the same way wherever back-to-back same-sender submissions happen.