### PR TITLE
feat: rotate stuck bundles to a fresh wallet and floor replacement gas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,12 +59,13 @@ pnpm run build:contracts-v08
 1. **Multi-version Support**: Each ERC-4337 version has dedicated handlers in separate directories (v06, v07, v08)
 2. **Chain Abstraction**: Chain-specific logic is isolated in handlers, allowing easy addition of new chains
 3. **Storage Flexibility**: Store interface allows switching between Redis and in-memory storage
-4. **Executor Strategies**: Supports different bundle submission strategies (conditional, flashbots)
+4. **Executor Strategies**: Supports different bundle submission strategies (conditional, flashbots). Stuck bundles are resubmitted with bumped gas (floored above the bor +10% replacement requirement), then rotated to a fresh executor wallet after `max-stuck-attempts-before-rotation` total attempts (cancelling the old transaction)
 5. **Comprehensive Validation**: Multiple validation layers including simulation, reputation, and paymaster checks
 
 ### Important Files
 - `src/cli/config/bundle.ts`: CLI configuration and option definitions
-- `src/executor/executor.ts`: Main bundle execution logic
+- `src/executor/executor.ts`: Main bundle execution logic (gas pricing, replacement gas floor)
+- `src/executor/executorManager.ts`: Block watching, stuck-bundle resubmission/rotation, recovery
 - `src/mempool/mempool.ts`: User operation mempool implementation
 - `src/rpc/server.ts`: RPC server setup
 - `src/validator/validator.ts`: User operation validation logic

--- a/src/cli/config/bundler.ts
+++ b/src/cli/config/bundler.ts
@@ -149,7 +149,8 @@ export const executorArgsSchema = z.object({
         .transform((val) => BigInt(val))
         .default("5"),
     "binary-search-max-retries": z.number().int().min(1).default(3),
-    "private-endpoint-submission-attempts": z.number().int().min(0).default(3)
+    "private-endpoint-submission-attempts": z.number().int().min(0).default(3),
+    "max-stuck-attempts-before-rotation": z.number().int().min(1).default(5)
 })
 
 export const compatibilityArgsSchema = z.object({

--- a/src/cli/config/options.ts
+++ b/src/cli/config/options.ts
@@ -463,6 +463,13 @@ export const executorOptions: CliCommandOptions<IExecutorArgsInput> = {
         type: "number",
         require: false,
         default: 3
+    },
+    "max-stuck-attempts-before-rotation": {
+        description:
+            "Total submission attempts on a stuck bundle's wallet (including the initial send) before rotating the userOps to a fresh executor wallet",
+        type: "number",
+        require: false,
+        default: 5
     }
 }
 

--- a/src/executor/executor.ts
+++ b/src/executor/executor.ts
@@ -39,6 +39,13 @@ import {
     isTransactionUnderpricedError
 } from "./utils"
 
+// bor/geth mempool only accepts a replacement transaction (same sender+nonce)
+// if it exceeds the pending transaction's gasFeeCap AND gasTipCap by at least
+// PriceBump (10% in geth's legacypool, inherited by Polygon bor). We bump by
+// 13% to keep rounding headroom so resubmissions are never rejected with
+// "replacement transaction underpriced".
+const REPLACEMENT_MIN_BUMP_PERCENT = 113n
+
 type HandleOpsTxParams = {
     gas: bigint
     account: Account
@@ -375,20 +382,26 @@ export class Executor {
         userOpBundle,
         networkGasPrice,
         networkBaseFee,
-        nonce
+        nonce,
+        previousTransactionRequest
     }: {
         executor: Account
         userOpBundle: UserOperationBundle
         networkGasPrice: GasPriceParameters
         networkBaseFee: bigint
         nonce: number
+        previousTransactionRequest?: {
+            maxFeePerGas: bigint
+            maxPriorityFeePerGas: bigint
+        }
     }): Promise<BundleResult> {
         const { entryPoint, userOps } = userOpBundle
 
         let childLogger = this.logger.child({
             submissionAttempts: userOpBundle.submissionAttempts,
             userOperations: getUserOpHashes(userOps),
-            entryPoint
+            entryPoint,
+            executor: executor.address
         })
 
         const filterOpsResult = await filterOpsAndEstimateGas({
@@ -432,16 +445,40 @@ export class Executor {
         childLogger = this.logger.child({
             submissionAttempts: userOpBundle.submissionAttempts,
             userOperations: getUserOpHashes(userOpsToBundle),
-            entryPoint
+            entryPoint,
+            executor: executor.address
         })
 
-        const { maxFeePerGas, maxPriorityFeePerGas } = this.getBundleGasPrice({
+        let { maxFeePerGas, maxPriorityFeePerGas } = this.getBundleGasPrice({
             bundle: userOpBundle,
             networkGasPrice,
             networkBaseFee,
             totalBeneficiaryFees,
             bundleGasUsed
         })
+
+        // When replacing a stuck transaction, the new bid must beat the previous
+        // transaction's fee caps by >= bor's PriceBump (10%) on BOTH maxFeePerGas
+        // and maxPriorityFeePerGas, or the node rejects it with "replacement
+        // transaction underpriced". The price above is derived from the
+        // fluctuating network price and can dip below the previous bid, so floor
+        // it to guarantee a valid replacement.
+        if (previousTransactionRequest) {
+            maxFeePerGas = maxBigInt(
+                maxFeePerGas,
+                scaleBigIntByPercent(
+                    previousTransactionRequest.maxFeePerGas,
+                    REPLACEMENT_MIN_BUMP_PERCENT
+                )
+            )
+            maxPriorityFeePerGas = maxBigInt(
+                maxPriorityFeePerGas,
+                scaleBigIntByPercent(
+                    previousTransactionRequest.maxPriorityFeePerGas,
+                    REPLACEMENT_MIN_BUMP_PERCENT
+                )
+            )
+        }
 
         let transactionHash: HexData32
         try {

--- a/src/executor/executorManager.ts
+++ b/src/executor/executorManager.ts
@@ -494,6 +494,20 @@ export class ExecutorManager {
             })
         } else if (isStuck) {
             this.bundleManager.stopTrackingBundle(submittedBundle)
+
+            // A stuck (not gas-too-low) bundle means the RPC accepted our tx
+            // but the network isn't including it. Bumping gas via
+            // replaceTransaction can't fix that and risks "replacement
+            // transaction underpriced" churn on bor. After a few attempts,
+            // rotate the userOps onto a fresh wallet + nonce instead.
+            if (
+                submittedBundle.bundle.submissionAttempts >=
+                this.config.maxStuckAttemptsBeforeRotation
+            ) {
+                this.rotateStuckBundle(submittedBundle)
+                return
+            }
+
             this.replaceTransaction({
                 blockReceivedTimestamp,
                 submittedBundle,
@@ -502,6 +516,69 @@ export class ExecutorManager {
                 reason: "stuck"
             })
         }
+    }
+
+    // Recover a bundle whose executor transaction is stuck (accepted by the RPC
+    // but not being mined). Re-queue the userOps so they are rebundled on a
+    // fresh wallet + nonce, and cancel the stuck transaction in the background
+    // so it can't later mine as a wasteful duplicate.
+    async rotateStuckBundle(
+        submittedBundle: SubmittedBundleInfo
+    ): Promise<void> {
+        const { bundle, executor, transactionRequest, transactionHash } =
+            submittedBundle
+        const { entryPoint, userOps } = bundle
+
+        this.logger.warn(
+            {
+                event: "rotatingStuckBundle",
+                userOperations: getUserOpHashes(userOps),
+                oldTxHash: transactionHash,
+                nonce: transactionRequest.nonce,
+                oldExecutor: executor.address,
+                submissionAttempts: bundle.submissionAttempts
+            },
+            "rotating stuck bundle to a fresh executor wallet"
+        )
+
+        this.metrics.replacedTransactions
+            .labels({ reason: "stuck", status: "rotated" })
+            .inc()
+
+        // Detach the userOps from the stuck (old) submitted bundle so the
+        // rebundle below doesn't double-track them in the submitted store.
+        await this.mempool.removeSubmittedUserOps({ entryPoint, userOps })
+
+        // Cancel the stuck transaction, then free its wallet once the nonce has
+        // advanced. Run in the background so recovery isn't blocked on cancel.
+        this.cancelBundle(submittedBundle)
+            .catch((err) =>
+                this.logger.error({ err }, "error cancelling stuck bundle")
+            )
+            .finally(() => this.senderManager.markWalletProcessed(executor))
+
+        // Re-bundle on a fresh wallet. The stuck wallet is still locked (freed
+        // only after the cancel above), so getWallet() picks a different one and
+        // the new tx uses a fresh nonce — there is no same-nonce bor replacement
+        // constraint, so no gas floor is carried. Passing the existing bundle
+        // preserves submissionAttempts, so the new tx starts at the already
+        // escalated gas level (bounded by resubmitMultiplierCeiling) rather than
+        // resetting to base — this avoids a livelock under sustained network
+        // load where each rotation would otherwise restart from network gas.
+        const newTxHash = await this.sendBundleToExecutor(bundle)
+
+        this.logger.warn(
+            {
+                event: "rotatedStuckBundle",
+                userOperations: getUserOpHashes(userOps),
+                oldTxHash: transactionHash,
+                oldExecutor: executor.address,
+                newTxHash
+            },
+            newTxHash
+                ? "stuck bundle rotated to a fresh executor wallet"
+                : "stuck bundle rotation failed to submit on a fresh wallet"
+        )
     }
 
     async cancelBundle(submittedBundle: SubmittedBundleInfo): Promise<void> {
@@ -616,7 +693,11 @@ export class ExecutorManager {
             networkGasPrice,
             networkBaseFee,
             userOpBundle: bundle,
-            nonce: transactionRequest.nonce
+            nonce: transactionRequest.nonce,
+            // Floor the new bid to the previous tx's fee caps + bump so bor
+            // accepts the replacement (avoids "replacement transaction
+            // underpriced" when the network price has dipped).
+            previousTransactionRequest: transactionRequest
         })
 
         // Handle case where no bundle was sent.

--- a/src/executor/executorManager.ts
+++ b/src/executor/executorManager.ts
@@ -9,6 +9,8 @@ import type {
 import type { GasPriceParameters } from "@alto/types"
 import { type Logger, type Metrics, scaleBigIntByPercent } from "@alto/utils"
 import {
+    type Account,
+    type Address,
     type Block,
     type Hex,
     type WatchBlocksReturnType,
@@ -22,6 +24,11 @@ import { getUserOpHashes } from "./utils"
 
 const SCALE_FACTOR = 10 // Interval increases by 10ms per task per minute
 const RPM_WINDOW = 60000 // 1 minute window in ms
+
+// While a rotated-away wallet is quarantined (its stuck nonce hasn't confirmed),
+// emit an error log every this-many reconcile ticks so a permanently wedged
+// wallet surfaces for alerting (~ this * blockTime between alerts).
+const QUARANTINE_ALERT_INTERVAL_TICKS = 30
 
 export class ExecutorManager {
     private senderManager: SenderManager
@@ -37,6 +44,21 @@ export class ExecutorManager {
     private unWatch: WatchBlocksReturnType | undefined
 
     private currentlyHandlingBlock = false
+
+    // Executor wallets rotated away from a stuck bundle whose cancel did not
+    // confirm. Held out of the sender pool (markWalletProcessed deferred) until
+    // their on-chain nonce advances past the stuck nonce, so no other instance
+    // can pop an unconfirmed nonce and collide.
+    private quarantinedWallets: Map<
+        Address,
+        {
+            wallet: Account
+            stuckNonce: number
+            quarantinedAt: number
+            ticks: number
+        }
+    > = new Map()
+    private quarantineTimer: NodeJS.Timeout | undefined
 
     constructor({
         config,
@@ -504,7 +526,12 @@ export class ExecutorManager {
                 submittedBundle.bundle.submissionAttempts >=
                 this.config.maxStuckAttemptsBeforeRotation
             ) {
-                this.rotateStuckBundle(submittedBundle)
+                this.rotateStuckBundle(submittedBundle).catch((err) =>
+                    this.logger.error(
+                        { err },
+                        "unhandled error rotating stuck bundle"
+                    )
+                )
                 return
             }
 
@@ -545,43 +572,187 @@ export class ExecutorManager {
             .labels({ reason: "stuck", status: "rotated" })
             .inc()
 
-        // Detach the userOps from the stuck (old) submitted bundle so the
-        // rebundle below doesn't double-track them in the submitted store.
-        await this.mempool.removeSubmittedUserOps({ entryPoint, userOps })
-
-        // Cancel the stuck transaction, then free its wallet once the nonce has
-        // advanced. Run in the background so recovery isn't blocked on cancel.
+        // Cancel the stuck transaction. Free the wallet ONLY if the cancel
+        // confirms (nonce advanced past the stuck nonce); otherwise quarantine
+        // it so no other instance can pop an unconfirmed nonce and collide.
+        // Runs in the background so recovery isn't blocked on cancel.
         this.cancelBundle(submittedBundle)
-            .catch((err) =>
-                this.logger.error({ err }, "error cancelling stuck bundle")
-            )
-            .finally(() => this.senderManager.markWalletProcessed(executor))
+            .then((confirmed) => {
+                if (confirmed) {
+                    return this.senderManager
+                        .markWalletProcessed(executor)
+                        .catch((err) =>
+                            this.logger.error(
+                                { err, executor: executor.address },
+                                "failed to free wallet after confirmed cancel"
+                            )
+                        )
+                }
+                this.quarantineWallet(executor, transactionRequest.nonce)
+                return undefined
+            })
+            .catch((err) => {
+                this.logger.error(
+                    { err, executor: executor.address },
+                    "error cancelling stuck bundle, quarantining wallet"
+                )
+                this.quarantineWallet(executor, transactionRequest.nonce)
+            })
 
-        // Re-bundle on a fresh wallet. The stuck wallet is still locked (freed
-        // only after the cancel above), so getWallet() picks a different one and
-        // the new tx uses a fresh nonce — there is no same-nonce bor replacement
-        // constraint, so no gas floor is carried. Passing the existing bundle
-        // preserves submissionAttempts, so the new tx starts at the already
-        // escalated gas level (bounded by resubmitMultiplierCeiling) rather than
-        // resetting to base — this avoids a livelock under sustained network
-        // load where each rotation would otherwise restart from network gas.
-        const newTxHash = await this.sendBundleToExecutor(bundle)
+        try {
+            // Detach the userOps from the stuck (old) submitted bundle so the
+            // rebundle below doesn't double-track them in the submitted store.
+            await this.mempool.removeSubmittedUserOps({ entryPoint, userOps })
+
+            // Re-bundle on a fresh wallet. The stuck wallet is still locked
+            // (freed only after the cancel above), so getWallet() picks a
+            // different one and the new tx uses a fresh nonce — there is no
+            // same-nonce bor replacement constraint, so no gas floor is carried.
+            // Passing the existing bundle preserves submissionAttempts, so the
+            // new tx starts at the already escalated gas level (bounded by
+            // resubmitMultiplierCeiling) rather than resetting to base — this
+            // avoids a livelock under sustained network load where each rotation
+            // would otherwise restart from network gas.
+            const newTxHash = await this.sendBundleToExecutor(bundle)
+
+            this.logger.warn(
+                {
+                    event: "rotatedStuckBundle",
+                    userOperations: getUserOpHashes(userOps),
+                    oldTxHash: transactionHash,
+                    oldExecutor: executor.address,
+                    newTxHash
+                },
+                newTxHash
+                    ? "stuck bundle rotated to a fresh executor wallet"
+                    : "stuck bundle rotation failed to submit on a fresh wallet"
+            )
+        } catch (err) {
+            // removeSubmittedUserOps / sendBundleToExecutor can throw on RPC
+            // failure. By this point the userOps may already be detached from
+            // the submitted store, so re-queue them to outstanding to avoid
+            // silently dropping them (this method is invoked fire-and-forget).
+            this.logger.error(
+                {
+                    err,
+                    userOperations: getUserOpHashes(userOps),
+                    oldTxHash: transactionHash
+                },
+                "stuck bundle rotation failed, resubmitting userOps"
+            )
+            await this.mempool
+                .resubmitUserOps({
+                    userOps,
+                    entryPoint,
+                    reason: "stuck_bundle_rotation_failed"
+                })
+                .catch((resubmitErr) =>
+                    this.logger.error(
+                        { err: resubmitErr },
+                        "failed to resubmit userOps after rotation failure"
+                    )
+                )
+        }
+    }
+
+    // Hold a rotated-away wallet out of the sender pool (markWalletProcessed
+    // deferred) until its stuck nonce confirms on-chain, so no other instance
+    // can pop an unconfirmed nonce and collide.
+    private quarantineWallet(wallet: Account, stuckNonce: number): void {
+        this.quarantinedWallets.set(wallet.address, {
+            wallet,
+            stuckNonce,
+            quarantinedAt: Date.now(),
+            ticks: 0
+        })
+        this.metrics.executorWalletsQuarantined.set(
+            this.quarantinedWallets.size
+        )
 
         this.logger.warn(
             {
-                event: "rotatedStuckBundle",
-                userOperations: getUserOpHashes(userOps),
-                oldTxHash: transactionHash,
-                oldExecutor: executor.address,
-                newTxHash
+                event: "walletQuarantined",
+                executor: wallet.address,
+                stuckNonce
             },
-            newTxHash
-                ? "stuck bundle rotated to a fresh executor wallet"
-                : "stuck bundle rotation failed to submit on a fresh wallet"
+            "executor wallet quarantined after failed cancel"
         )
+
+        if (!this.quarantineTimer) {
+            this.quarantineTimer = setInterval(
+                () => this.reconcileQuarantinedWallets(),
+                this.config.blockTime
+            )
+        }
     }
 
-    async cancelBundle(submittedBundle: SubmittedBundleInfo): Promise<void> {
+    // Poll quarantined wallets; release one back to the pool once its on-chain
+    // nonce has advanced past the stuck nonce (cancel or original tx mined).
+    // Watch-only: never force-frees a wallet whose nonce hasn't advanced.
+    private async reconcileQuarantinedWallets(): Promise<void> {
+        for (const [address, entry] of [...this.quarantinedWallets]) {
+            const { wallet, stuckNonce, quarantinedAt } = entry
+
+            const latestNonce = await this.config.publicClient
+                .getTransactionCount({ address, blockTag: "latest" })
+                .catch(() => undefined)
+
+            // RPC error — leave quarantined, retry next tick.
+            if (latestNonce === undefined) {
+                continue
+            }
+
+            // Stuck slot resolved -> safe to return the wallet to the pool.
+            if (latestNonce > stuckNonce) {
+                this.quarantinedWallets.delete(address)
+                this.metrics.executorWalletsQuarantined.set(
+                    this.quarantinedWallets.size
+                )
+                await this.senderManager
+                    .markWalletProcessed(wallet)
+                    .catch((err) =>
+                        this.logger.error(
+                            { err, executor: address },
+                            "failed to release quarantined wallet"
+                        )
+                    )
+                this.logger.info(
+                    {
+                        event: "walletReleasedFromQuarantine",
+                        executor: address,
+                        stuckNonce,
+                        latestNonce,
+                        quarantinedTicks: entry.ticks
+                    },
+                    "executor wallet released from quarantine"
+                )
+                continue
+            }
+
+            // Still wedged: escalate periodically so a permanently stuck wallet
+            // surfaces for alerting (query: event:"walletQuarantineStuck").
+            entry.ticks += 1
+            if (entry.ticks % QUARANTINE_ALERT_INTERVAL_TICKS === 0) {
+                this.logger.error(
+                    {
+                        event: "walletQuarantineStuck",
+                        executor: address,
+                        stuckNonce,
+                        quarantinedTicks: entry.ticks,
+                        quarantinedMs: Date.now() - quarantinedAt
+                    },
+                    "executor wallet stuck in quarantine — manual intervention may be required"
+                )
+            }
+        }
+
+        if (this.quarantinedWallets.size === 0 && this.quarantineTimer) {
+            clearInterval(this.quarantineTimer)
+            this.quarantineTimer = undefined
+        }
+    }
+
+    async cancelBundle(submittedBundle: SubmittedBundleInfo): Promise<boolean> {
         const {
             bundle: { userOps },
             executor,
@@ -607,7 +778,7 @@ export class ExecutorManager {
 
                 if (currentNonce > transactionRequest.nonce) {
                     logger.info("Transaction already mined or cancelled")
-                    return
+                    return true
                 }
 
                 logger.info(`Trying to cancel bundle, attempt ${attempt + 1}`)
@@ -652,6 +823,7 @@ export class ExecutorManager {
             { transactionHash },
             "failed to cancel bundle after max retries"
         )
+        return false
     }
 
     async replaceTransaction({

--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -203,6 +203,13 @@ export function createMetrics(registry: Registry, register = true) {
         registers
     })
 
+    const executorWalletsQuarantined = new Gauge({
+        name: "ultra_relay_executor_wallets_quarantined",
+        help: "Number of executor wallets held out of the pool pending stuck-nonce confirmation",
+        labelNames: [] as const,
+        registers
+    })
+
     const emittedOpEvents = new Counter({
         name: "ultra_relay_emitted_user_operation_events",
         help: "Total number of emitted UserOperation status events",
@@ -247,6 +254,7 @@ export function createMetrics(registry: Registry, register = true) {
         utilityWalletInsufficientBalance,
         executorWalletsBalances,
         executorWalletsMinBalance,
+        executorWalletsQuarantined,
         emittedOpEvents,
         walletsProcessingTime,
         userOperationsSubmissionAttempts,


### PR DESCRIPTION
 ## Summary

  Guard rails for stuck executor transactions on Polygon (bor) and similar chains. After an incident where a userOp took ~2 min: an executor tx sat unmined for ~18 min while the resubmit loop escalated gas (up to 2338 gwei) and eventually hit `replacement transaction
  underpriced`. The userOp was only delivered when a failure incidentally re-bundled it onto a fresh wallet; the original tx later mined as a wasteful AA25 duplicate.

  ## Changes

  1. **Replacement gas floor** (`executor.ts`): when replacing a stuck tx, floor both `maxFeePerGas` and `maxPriorityFeePerGas` to `previousBid × 1.13`, so same-(sender, nonce) replacements always clear bor/geth's `PriceBump` (10%) requirement even when the network 
  estimate dips. Avoids `replacement transaction underpriced` (geth `legacypool`; magnitude documented in EIP-2831 / EIP-4844).

  2. **Stuck-bundle wallet rotation** (`executorManager.ts`): after `max-stuck-attempts-before-rotation` total attempts on a stuck (not gas-too-low) bundle, rotate the userOps to a fresh executor wallet + nonce instead of escalating gas forever. The fresh tx preserves 
  the bundle's `submissionAttempts`, so it starts at the already-escalated gas level (bounded by `resubmitMultiplierCeiling`) rather than resetting to network base. The fresh nonce has no same-nonce replacement constraint, so no gas floor is carried.

  3. **Cancel old tx on rotation**: the stuck tx is cancelled (no-op self-transfer at its nonce) in the background so it can't mine later as a duplicate and burn gas.

  4. **Config**: new `--max-stuck-attempts-before-rotation` (default 5; counts total attempts incl. the initial send → rotate on the 6th).

  5. **Observability**: bundle/rotation logs now carry the executor address and userOp hashes (`rotatingStuckBundle` / `rotatedStuckBundle` link old→new wallet+tx), so a single userOpHash query reconstructs the full path.

  ## Out of scope
  - Gas-oracle accuracy (if the estimate severely under-reports under load) — separate concern.
  - No new absolute gas cap: break-even-based cap is unusable (boosted/paymaster-less ops have 0 fees → 0 break-even); escalation stays bounded by the existing 300% `resubmitMultiplierCeiling`.

  ## Test plan
  - [ ] e2e: stuck tx → rotation to fresh wallet → inclusion
  - [ ] replacement gas floor prevents underpriced on network dip