### PR TITLE
feat: add max-priority-fee-per-gas-cap (ceiling for the oracle tip)

### DIFF
--- a/src/cli/config/bundler.ts
+++ b/src/cli/config/bundler.ts
@@ -188,6 +188,10 @@ export const compatibilityArgsSchema = z.object({
         .string()
         .transform((val) => parseGwei(val))
         .optional(),
+    "max-priority-fee-per-gas-cap": z
+        .string()
+        .transform((val) => parseGwei(val))
+        .optional(),
     "supports-eip7623": z.boolean().default(false)
 })
 

--- a/src/cli/config/options.ts
+++ b/src/cli/config/options.ts
@@ -540,6 +540,12 @@ export const compatibilityOptions: CliCommandOptions<ICompatibilityArgsInput> =
             type: "string",
             require: false
         },
+        "max-priority-fee-per-gas-cap": {
+            description:
+                "Maximum value for maxPriorityFeePerGas to enforce (in gwei). Caps the tip taken from the network gas oracle. On low-traffic chains the oracle can feedback-loop on the bundler's own past tips and report an absurd value; without a ceiling the bundler bids it verbatim and overpays. maxFeePerGas is reduced by the same amount the tip is capped.",
+            type: "string",
+            require: false
+        },
         "supports-eip7623": {
             description:
                 "Whether the chain supports EIP-7623 (Increase calldata cost to reduce maximum block size)",

--- a/src/handlers/gasPriceManager.ts
+++ b/src/handlers/gasPriceManager.ts
@@ -131,29 +131,41 @@ export class GasPriceManager {
             maxPriorityFeePerGas: (maxPriorityFeePerGas * bumpAmount) / 100n
         }
 
-        if (
-            this.config.floorMaxFeePerGas ||
-            this.config.floorMaxPriorityFeePerGas
-        ) {
-            const maxFeePerGas = this.config.floorMaxFeePerGas
-                ? maxBigInt(this.config.floorMaxFeePerGas, result.maxFeePerGas)
-                : result.maxFeePerGas
+        let finalMaxFeePerGas = this.config.floorMaxFeePerGas
+            ? maxBigInt(this.config.floorMaxFeePerGas, result.maxFeePerGas)
+            : result.maxFeePerGas
 
-            const maxPriorityFeePerGas = this.config.floorMaxPriorityFeePerGas
-                ? maxBigInt(
-                      this.config.floorMaxPriorityFeePerGas,
-                      result.maxPriorityFeePerGas
-                  )
-                : result.maxPriorityFeePerGas
+        let finalMaxPriorityFeePerGas = this.config.floorMaxPriorityFeePerGas
+            ? maxBigInt(
+                  this.config.floorMaxPriorityFeePerGas,
+                  result.maxPriorityFeePerGas
+              )
+            : result.maxPriorityFeePerGas
 
-            return {
-                // Ensure that maxFeePerGas is always greater or equal than maxPriorityFeePerGas
-                maxFeePerGas: maxBigInt(maxFeePerGas, maxPriorityFeePerGas),
-                maxPriorityFeePerGas
-            }
+        // Ceiling on the priority fee taken from the network gas oracle. On
+        // low-traffic chains the eth_maxPriorityFeePerGas oracle can feedback-loop
+        // on the bundler's own past tips and report an absurd value (e.g. 500 gwei
+        // on a 20 gwei base-fee, empty-block chain), which we'd otherwise bid
+        // verbatim and overpay ~25x. Cap the tip and reduce maxFeePerGas by the
+        // same delta so we don't pay an inflated tip. Applied after the floors so
+        // the cap always wins if both are configured. The base-fee component of
+        // maxFeePerGas is preserved, so this never pushes maxFeePerGas below the
+        // base fee.
+        if (this.config.maxPriorityFeePerGasCap !== undefined) {
+            const cappedPriorityFee = minBigInt(
+                finalMaxPriorityFeePerGas,
+                this.config.maxPriorityFeePerGasCap
+            )
+            const priorityFeeDelta = finalMaxPriorityFeePerGas - cappedPriorityFee
+            finalMaxFeePerGas -= priorityFeeDelta
+            finalMaxPriorityFeePerGas = cappedPriorityFee
         }
 
-        return result
+        return {
+            // Ensure that maxFeePerGas is always greater or equal than maxPriorityFeePerGas
+            maxFeePerGas: maxBigInt(finalMaxFeePerGas, finalMaxPriorityFeePerGas),
+            maxPriorityFeePerGas: finalMaxPriorityFeePerGas
+        }
     }
 
     private async getFallBackMaxPriorityFeePerGas(

--- a/src/handlers/gasPriceManager.ts
+++ b/src/handlers/gasPriceManager.ts
@@ -131,36 +131,16 @@ export class GasPriceManager {
             maxPriorityFeePerGas: (maxPriorityFeePerGas * bumpAmount) / 100n
         }
 
-        let finalMaxFeePerGas = this.config.floorMaxFeePerGas
+        const finalMaxFeePerGas = this.config.floorMaxFeePerGas
             ? maxBigInt(this.config.floorMaxFeePerGas, result.maxFeePerGas)
             : result.maxFeePerGas
 
-        let finalMaxPriorityFeePerGas = this.config.floorMaxPriorityFeePerGas
+        const finalMaxPriorityFeePerGas = this.config.floorMaxPriorityFeePerGas
             ? maxBigInt(
                   this.config.floorMaxPriorityFeePerGas,
                   result.maxPriorityFeePerGas
               )
             : result.maxPriorityFeePerGas
-
-        // Ceiling on the priority fee taken from the network gas oracle. On
-        // low-traffic chains the eth_maxPriorityFeePerGas oracle can feedback-loop
-        // on the bundler's own past tips and report an absurd value (e.g. 500 gwei
-        // on a 20 gwei base-fee, empty-block chain), which we'd otherwise bid
-        // verbatim and overpay ~25x. Cap the tip and reduce maxFeePerGas by the
-        // same delta so we don't pay an inflated tip. Applied after the floors so
-        // the cap always wins if both are configured. The base-fee component of
-        // maxFeePerGas is preserved, so this never pushes maxFeePerGas below the
-        // base fee.
-        if (this.config.maxPriorityFeePerGasCap !== undefined) {
-            const cappedPriorityFee = minBigInt(
-                finalMaxPriorityFeePerGas,
-                this.config.maxPriorityFeePerGasCap
-            )
-            const priorityFeeDelta =
-                finalMaxPriorityFeePerGas - cappedPriorityFee
-            finalMaxFeePerGas -= priorityFeeDelta
-            finalMaxPriorityFeePerGas = cappedPriorityFee
-        }
 
         return {
             // Ensure that maxFeePerGas is always greater or equal than maxPriorityFeePerGas
@@ -170,6 +150,30 @@ export class GasPriceManager {
             ),
             maxPriorityFeePerGas: finalMaxPriorityFeePerGas
         }
+    }
+
+    private applyMaxPriorityFeePerGasCap(
+        gasPriceParameters: GasPriceParameters
+    ): GasPriceParameters {
+        // Apply after final lower-bound checks so the oracle value cannot restore
+        // an uncapped priority fee.
+        if (this.config.maxPriorityFeePerGasCap !== undefined) {
+            const cappedPriorityFee = minBigInt(
+                gasPriceParameters.maxPriorityFeePerGas,
+                this.config.maxPriorityFeePerGasCap
+            )
+            const priorityFeeDelta =
+                gasPriceParameters.maxPriorityFeePerGas - cappedPriorityFee
+            const maxFeePerGas =
+                gasPriceParameters.maxFeePerGas - priorityFeeDelta
+
+            return {
+                maxFeePerGas: maxBigInt(maxFeePerGas, cappedPriorityFee),
+                maxPriorityFeePerGas: cappedPriorityFee
+            }
+        }
+
+        return gasPriceParameters
     }
 
     private async getFallBackMaxPriorityFeePerGas(
@@ -295,7 +299,7 @@ export class GasPriceManager {
                     maxPriorityFeePerGas: polygonEstimate.maxPriorityFeePerGas
                 })
 
-                return {
+                return this.applyMaxPriorityFeePerGasCap({
                     maxFeePerGas: maxBigInt(
                         gasPrice.maxFeePerGas,
                         maxFeePerGas
@@ -304,7 +308,7 @@ export class GasPriceManager {
                         gasPrice.maxPriorityFeePerGas,
                         maxPriorityFeePerGas
                     )
-                }
+                })
             }
         }
 
@@ -312,13 +316,13 @@ export class GasPriceManager {
             const gasPrice = this.bumpTheGasPrice(
                 await this.getLegacyTransactionGasPrice()
             )
-            return {
+            return this.applyMaxPriorityFeePerGasCap({
                 maxFeePerGas: maxBigInt(gasPrice.maxFeePerGas, maxFeePerGas),
                 maxPriorityFeePerGas: maxBigInt(
                     gasPrice.maxPriorityFeePerGas,
                     maxPriorityFeePerGas
                 )
-            }
+            })
         }
 
         const estimatedPrice = await this.estimateGasPrice()
@@ -330,13 +334,13 @@ export class GasPriceManager {
             maxFeePerGas,
             maxPriorityFeePerGas
         })
-        return {
+        return this.applyMaxPriorityFeePerGasCap({
             maxFeePerGas: maxBigInt(gasPrice.maxFeePerGas, maxFeePerGas),
             maxPriorityFeePerGas: maxBigInt(
                 gasPrice.maxPriorityFeePerGas,
                 maxPriorityFeePerGas
             )
-        }
+        })
     }
 
     // This method throws if it can't get a valid RPC response.

--- a/src/handlers/gasPriceManager.ts
+++ b/src/handlers/gasPriceManager.ts
@@ -156,14 +156,18 @@ export class GasPriceManager {
                 finalMaxPriorityFeePerGas,
                 this.config.maxPriorityFeePerGasCap
             )
-            const priorityFeeDelta = finalMaxPriorityFeePerGas - cappedPriorityFee
+            const priorityFeeDelta =
+                finalMaxPriorityFeePerGas - cappedPriorityFee
             finalMaxFeePerGas -= priorityFeeDelta
             finalMaxPriorityFeePerGas = cappedPriorityFee
         }
 
         return {
             // Ensure that maxFeePerGas is always greater or equal than maxPriorityFeePerGas
-            maxFeePerGas: maxBigInt(finalMaxFeePerGas, finalMaxPriorityFeePerGas),
+            maxFeePerGas: maxBigInt(
+                finalMaxFeePerGas,
+                finalMaxPriorityFeePerGas
+            ),
             maxPriorityFeePerGas: finalMaxPriorityFeePerGas
         }
     }


### PR DESCRIPTION
## Problem
`gasPriceManager` has gas **floors** (`floor-max-fee-per-gas`, `floor-max-priority-fee-per-gas`) but **no ceiling** — it bids whatever `eth_maxPriorityFeePerGas` returns, verbatim.

On low-traffic chains where the bundler is the dominant tx sender, the priority-fee oracle **feedback-loops on the bundler's own past tips** and reports an absurd value. Observed on **Arc mainnet**:
- base fee sits at the **20 gwei protocol floor**, blocks **0% full**
- but `eth_maxPriorityFeePerGas` returns **500 gwei**, and the executor bids it
- per Arc's docs, a **0 gwei tip is accepted** (1 gwei suggested for congestion), target **~$0.01/tx**
- result: each tx costs **~0.24–0.36 USDC** instead of ~0.01 — a **~25× overpay** that repeatedly drains the executor wallet

There's no config knob to cap this today (floors only raise; `gas-price-bump < 100` scales a moving oracle and undershoots below base fee as the loop unwinds → stalls). So it needs a ceiling primitive.

## Change
Add an optional `max-priority-fee-per-gas-cap` (gwei, parsed like the floors). When set:
- the priority fee is capped to it via `minBigInt`
- `maxFeePerGas` is reduced by the same delta, so the **base-fee component is preserved** (never pushes maxFee below the base fee) and we don't pay an inflated tip
- applied **after** the floors, so the cap wins if both are configured
- **no behavior change when unset**

`bumpTheGasPrice` is refactored to a single return so floors + cap compose cleanly.

It's also self-correcting: once the bundler bids capped tips, the oracle's percentile of recent tips drops within a few blocks and the loop unwinds.

## Rollout
Set on the affected chain's config, e.g. Arc:
```json
"max-priority-fee-per-gas-cap": "5"
```
(5 gwei = 5× Arc's suggested tip, ~100× below the looped 500; lands at ~$0.01/tx — Arc's target. Base fee is still paid in full and can rise legitimately under real congestion.) Other low-traffic chains where the bundler dominates can set it as needed; leaving it unset preserves current behavior.